### PR TITLE
Fixes & Updates to preferences

### DIFF
--- a/devicetypes/bspranger/xiaomi-aqara-button.src/xiaomi-aqara-button.groovy
+++ b/devicetypes/bspranger/xiaomi-aqara-button.src/xiaomi-aqara-button.groovy
@@ -40,15 +40,6 @@
  *
  */
 
-preferences {
-	input name:"ReleaseTime", type:"number", title:"Minimum time in seconds for a press to clear", defaultValue: 2, displayDuringSetup: false
-        input name:"PressType", type:"enum", options:["Toggle", "Momentary"], description:"Effects how the button toggles", defaultValue:"Toggle", displayDuringSetup: true
-	input name: "dateformat", type: "enum", title: "Set Date Format\n US (MDY) - UK (DMY) - Other (YMD)", description: "Date Format", required: false, options:["US","UK","Other"]
-	input description: "Only change the settings below if you know what you're doing", displayDuringSetup: false, type: "paragraph", element: "paragraph", title: "ADVANCED SETTINGS"
-	input name: "voltsmax", title: "Max Volts\nA battery is at 100% at __ volts\nRange 2.8 to 3.4", type: "decimal", range: "2.8..3.4", defaultValue: 3, required: false
-	input name: "voltsmin", title: "Min Volts\nA battery is at 0% (needs replacing) at __ volts\nRange 2.0 to 2.7", type: "decimal", range: "2..2.7", defaultValue: 2.5, required: false
-} 
-
 metadata {
     definition (name: "Xiaomi Aqara Button", namespace: "bspranger", author: "bspranger") {
         capability "Configuration"
@@ -111,7 +102,15 @@ metadata {
 
         main (["button"])
         details(["button","battery","empty2x2","empty2x2","lastcheckin","batteryRuntime","refresh"])
-   }
+    }
+    preferences {
+	input name: "ReleaseTime", type: "number", title:"Minimum time in seconds for a press to clear", description: “Enter number of seconds”, range: “0..7200”, defaultValue: 2, required: false
+        input name: "PressType", type:"enum", options: ["Toggle", "Momentary"], description: "Effects how the button toggles", defaultValue:"Toggle", required: false
+        input name: "dateformat", type: "enum", title: "Set Date Format\nUS (MDY), UK (DMY), or Other (YMD)", description: "Date Format", defaultValue: "US", required: false, options:["US","UK","Other"]
+        input description: "Only change the settings below if you know what you're doing.", type: "paragraph", element: "paragraph", title: "ADVANCED SETTINGS"
+        input name: "voltsmax", type: "decimal", title: "Max Volts  (range 2.8 to 3.4)\nBattery is at 100% at __ volts", range: "2.8..3.4", defaultValue: 3, required: false
+        input name: "voltsmin", type: "decimal", title: "Min Volts  (range 2.0 to 2.7)\nBattery is at 0% (needs replacing)\nat __ volts", range: "2..2.7", defaultValue: 2.5, required: false
+    }
 }
 
 def parse(String description) {
@@ -215,12 +214,12 @@ private Map getBatteryResult(rawValue) {
     def minVolts
     def maxVolts
 
-    if(voltsmin == null || voltsmin == "")
+    if (voltsmin == null || voltsmin == "")
     	minVolts = 2.5
     else
    	minVolts = voltsmin
     
-    if(voltsmax == null || voltsmax == "")
+    if (voltsmax == null || voltsmax == "")
     	maxVolts = 3.0
     else
 	maxVolts = voltsmax    


### PR DESCRIPTION
I had a read through the SmartThings Developer Documentation on [Preferences and Settings](http://docs.smartthings.com/en/latest/smartapp-developers-guide/preferences-and-settings.html), and found that the required: true and `displayDuringSetup: true` parameters are really meant for SmartApps, _not_ device handlers. Also, I tried using the `Section ()` definition to separate different settings, but apparently that only works with SmartApps, not with device handlers.

Interestingly, on the Developer Documentation [page for Device Handlers](http://docs.smartthings.com/en/latest/device-type-developers-guide/device-preferences.html), there’s a note at the very bottom that recommends not using defaultValue for preferences. From all my testing, I disagree that it causes any issues, but conditional checks for `null` or "" values on preference setting variables should be left in the code just in case. This documentation web page also clearly shows that the `preferences{}` section should be _inside_ `metadata{}` and all examples show it comes after the `definition()` and `tiles()` sections.

Here are changes I've made:

In all DTHs:
• moved the `preferences{}` section inside `metadata{}`, below `definition()` and `tiles()`
• removed all section{} references
• removed all `displayDuringSetup: true` references
• changed all `required:` to `false`
• added default values to any preferences that didn’t have them
• reworked / edited the Date Format and Max/Volts description text for clarity and better formatting

In all DTHs with offset settings:
• added `type: "decimal"` (only allows input of numbers)
• added `range: "-X..Y"` parameters, using appropriate X / Y values based on the type of offset

In the motion detector DTHs:
Motion Reset preference -
• added `type: "number"` (only allows input of integers without decimal values)
• added `range: "1..7200"`  to make sure only numerical values are input, but 0 and negative numbers are not allowed
• changed `default:` to `60` second to match the 60 second sensor hardware reset delay 
• edited the explanation text for clarity and moved it below the setting as a "NOTE:"

In the Temp/Humidity DTHs:
• added humidity offset preference - please double check `parseHumidity()` function for my changes!!