### PR TITLE
A solution for the Time Zone not set issue!

### DIFF
--- a/devicetypes/bspranger/xiaomi-aqara-button.src/xiaomi-aqara-button.groovy
+++ b/devicetypes/bspranger/xiaomi-aqara-button.src/xiaomi-aqara-button.groovy
@@ -344,22 +344,32 @@ private checkIntervalEvent(text) {
 }
 
 def formatDate(batteryReset) {
+    def correctedTimezone = ""
+
+    if (!(location.timeZone)) {
+        correctedTimezone = TimeZone.getTimeZone("GMT")
+        log.error "${device.displayName}: Time Zone not set, so GMT was used. Please set up your location in the SmartThings mobile app."
+        sendEvent(name: "error", value: "", descriptionText: "ERROR: Time Zone not set, so GMT was used. Please set up your location in the SmartThings mobile app.")
+    } 
+    else {
+        correctedTimezone = location.timeZone
+    }
     if (dateformat == "US" || dateformat == "" || dateformat == null) {
         if (batteryReset)
-            return new Date().format("MMM dd yyyy", location.timeZone)
+            return new Date().format("MMM dd yyyy", correctedTimezone)
         else
-            return new Date().format("EEE MMM dd yyyy h:mm:ss a", location.timeZone)
+            return new Date().format("EEE MMM dd yyyy h:mm:ss a", correctedTimezone)
     }
     else if (dateformat == "UK") {
         if (batteryReset)
-            return new Date().format("dd MMM yyyy", location.timeZone)
+            return new Date().format("dd MMM yyyy", correctedTimezone)
         else
-            return new Date().format("EEE dd MMM yyyy h:mm:ss a", location.timeZone)
+            return new Date().format("EEE dd MMM yyyy h:mm:ss a", correctedTimezone)
         }
     else {
         if (batteryReset)
-            return new Date().format("yyyy MMM dd", location.timeZone)
+            return new Date().format("yyyy MMM dd", correctedTimezone)
         else
-            return new Date().format("EEE yyyy MMM dd h:mm:ss a", location.timeZone)
+            return new Date().format("EEE yyyy MMM dd h:mm:ss a", correctedTimezone)
     }
 }


### PR DESCRIPTION
After playing around with the TimeZone.getTimeZone() call, I finally figured out how to force a default Time Zone for all date formats if the user hasn't set up their location yet. I used GMT as the default in this case.

Also, an error message will be shown in Live Logging as well as an event log message alerting the user to the issue and instructing them to set up their location in the SmarThings mobile app.

Because I already have my location set, I tested this by removing the not conditional like this: if ((location.timeZone)) con confirm no Groovy errors, and GMT was definitely used because the times shown in the panes were GMT times.

I sincerely hope this avoids any future problems with users that haven't set their location yet!